### PR TITLE
[Fix] Connect hangs in lollipop

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,9 +1,12 @@
 repositories {
     jcenter()
     mavenCentral()
+    maven {
+            url 'https://dl.bintray.com/mreverter/maven/'
+    }
 }
 
 dependencies {
-    compile 'com.mercadopago:connect:1.0.7'
+    compile 'com.mercadopago:connect:1.0.8'
     compile ('com.mercadopago:sdk:2.5.3@aar') { transitive = true }
 }


### PR DESCRIPTION
Actualizo la versión de connect.

**Aclaración:** no pude subir la librería a la cuenta de Bintray donde se sube regularmente. Algo cambió en la plataforma, y por lo que vi hay que aprobar la subida desde ahí (no tenemos acceso, tenemos que cambiar las cuentas urgente). Provisoriamente lo subo a mi cuenta.